### PR TITLE
Updated imports, moved metrics calls to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ optional arguments:
                         name of input file to load data from
   -t {vflip,hflip,blur,noise,brightness,crop}, --transformation {vflip,hflip,blur,noise,brightness,crop}
                         transformation to perform on data
-  -m {all,mse,mae,rmse,grad}, --metric {all,mse,mae,rmse,grad,s1,psnr,ncc,gds,gmd,gpd,hist-int,hog-pearsonfourier-similarity,wavelet-similarity} 
+  -m {all,mse,mae,rmse,grad}, --metric {all,mse,mae,rmse,grad,s1,psnr,ncc,gds,gmd,gpd,hist-int,hog-pearson,fourier-similarity,wavelet-similarity,tv,grad-tv,fourier-tv,wavelet-tv} 
                         evaluation metric to compute
   --visualize           visualize and save the operations
   -o OUTPUT, --output OUTPUT
@@ -50,6 +50,10 @@ $ python benchmark.py -s xor -t blur -m all --visualize -o ../media/synthetic.pn
 => hog-pearson: 0.6305659890823435
 => fourier-similarity: 1.0
 => wavelet-similarity: 0.13379014374033754
+=> tv: (524288, 273158)
+=> grad-tv: (3153888.0, 2151308.0)
+=> fourier-tv: (38639962.24096394, 31919021.24357993)
+=> wavelet-tv: (8388608.0, 8360728.0)
 ```
 ![](media/synthetic.png)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ optional arguments:
                         name of input file to load data from
   -t {vflip,hflip,blur,noise,brightness,crop}, --transformation {vflip,hflip,blur,noise,brightness,crop}
                         transformation to perform on data
-  -m {all,mse,mae,rmse,grad}, --metric {all,mse,mae,rmse,grad,s1,psnr,ncc,gds,gmd,gpd,hist-int,hog-pearson} 
+  -m {all,mse,mae,rmse,grad}, --metric {all,mse,mae,rmse,grad,s1,psnr,ncc,gds,gmd,gpd,hist-int,hog-pearsonfourier-similarity,wavelet-similarity} 
                         evaluation metric to compute
   --visualize           visualize and save the operations
   -o OUTPUT, --output OUTPUT
@@ -48,6 +48,8 @@ $ python benchmark.py -s xor -t blur -m all --visualize -o ../media/synthetic.pn
 => hist-int: 0.645227694933976
 => gpd: 2540086.6786078764
 => hog-pearson: 0.6305659890823435
+=> fourier-similarity: 1.0
+=> wavelet-similarity: 0.13379014374033754
 ```
 ![](media/synthetic.png)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ optional arguments:
                         name of input file to load data from
   -t {vflip,hflip,blur,noise,brightness,crop}, --transformation {vflip,hflip,blur,noise,brightness,crop}
                         transformation to perform on data
-  -m {all,mse,mae,rmse,grad}, --metric {all,mse,mae,rmse,grad}
+  -m {all,mse,mae,rmse,grad}, --metric {all,mse,mae,rmse,grad,s1,psnr,ncc,gds,gmd,gpd,hist-int,hog-pearson} 
                         evaluation metric to compute
   --visualize           visualize and save the operations
   -o OUTPUT, --output OUTPUT
@@ -36,10 +36,18 @@ Generate synthetic data, apply a bluring transformation, compute all metrics, an
 
 ```bash
 $ python benchmark.py -s xor -t blur -m all --visualize -o ../media/synthetic.png
-=> mse: 151.15902709960938
-=> mae: 7.190582275390625
-=> rmse: 12.294674745580274
-=> grad: (6.91624727961359e-19, 4.611219388020603e-19)
+=> mse: 151.15780639648438
+=> mae: 7.190338134765625
+=> rmse: 12.294625101908736
+=> grad: (6.91624727961359e-19, 4.611330123778287e-19)
+=> s1: (3.4584340177879653, 5.106637918264621)
+=> psnr: 26.336497800628308
+=> ncc: 0.9965684732341967
+=> gds: 0.493354541101387
+=> gmd: 2381696.5929986304
+=> hist-int: 0.645227694933976
+=> gpd: 2540086.6786078764
+=> hog-pearson: 0.6305659890823435
 ```
 ![](media/synthetic.png)
 

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,8 @@ dependencies:
   - numba
   - cython
   - pip:
+    - opencv-python
+    - scikit-image
     - tensorflow
     - tensorflow-probability
     - .

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,20 @@ import os
 
 # For guidance on setuptools best practices visit
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/
-project_name = os.getcwd().split("/")[-1]
+project_name = "sharpness"
 version = "0.1.0"
 package_description = "<Provide short description of package>"
 url = "https://github.com/ai2es/" + project_name
 # Classifiers listed at https://pypi.org/classifiers/
 classifiers = ["Programming Language :: Python :: 3"]
-setup(name=project_name, # Change
-      version=version,
-      description=package_description,
-      url=url,
-      author="AI2ES",
-      license="CC0 1.0",
-      classifiers=classifiers,
-      packages=find_packages(include=["src"]))
+setup(
+    name=project_name,
+    version=version,
+    description=package_description,
+    url=url,
+    author="AI2ES",
+    license="CC0 1.0",
+    classifiers=classifiers,
+    packages=["sharpness"],  # Specify the package name here
+    package_dir={"sharpness": "src"},  # Specify the directory mapping
+)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,11 @@
-from .metrics import mse, mae, rmse, grad, s1
+from .metrics import (
+    mse,
+    mae,
+    rmse,
+    grad,
+    s1,
+    total_variation
+)
 from .gradient import (
     psnr,
     normalized_cross_correlation,
@@ -6,10 +13,17 @@ from .gradient import (
     gradient_magnitude_difference,
     histogram_intersection,
     gradient_profile_difference,
-    hog_pearson
+    hog_pearson,
+    grad_total_variation
 )
-from .fourier import fourier_image_similarity
-from .wavelet import wavelet_image_similarity
+from .fourier import (
+    fourier_image_similarity,
+    fourier_total_variation
+)
+from .wavelet import (
+    wavelet_image_similarity,
+    wavelet_total_variation
+)
 
 metric_f = {
     'mse': mse,
@@ -25,10 +39,14 @@ metric_f = {
     "gpd": gradient_profile_difference,
     "hog-pearson": hog_pearson,
     "fourier-similarity": fourier_image_similarity,
-    "wavelet-similarity": wavelet_image_similarity
+    "wavelet-similarity": wavelet_image_similarity,
+    "tv": total_variation,
+    "grad-tv": grad_total_variation,
+    "fourier-tv": fourier_total_variation,
+    "wavelet-tv": wavelet_total_variation
 }
 
-single_metrics = ["grad", "s1"]
+single_metrics = ["grad", "s1", "tv", "grad-tv", "fourier-tv", "wavelet-tv"]
 
 
 def compute_all_metrics(X, T) -> dict:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,6 +8,8 @@ from .gradient import (
     gradient_profile_difference,
     hog_pearson
 )
+from .fourier import fourier_image_similarity
+from .wavelet import wavelet_image_similarity
 
 metric_f = {
     'mse': mse,
@@ -21,7 +23,9 @@ metric_f = {
     "gmd": gradient_magnitude_difference,
     "hist-int": histogram_intersection,
     "gpd": gradient_profile_difference,
-    "hog-pearson": hog_pearson
+    "hog-pearson": hog_pearson,
+    "fourier-similarity": fourier_image_similarity,
+    "wavelet-similarity": wavelet_image_similarity
 }
 
 single_metrics = ["grad", "s1"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,66 @@
+from .metrics import mse, mae, rmse, grad, s1
+from .gradient import (
+    psnr,
+    normalized_cross_correlation,
+    gradient_difference_similarity,
+    gradient_magnitude_difference,
+    histogram_intersection,
+    gradient_profile_difference,
+    hog_pearson
+)
+
+metric_f = {
+    'mse': mse,
+    'mae': mae,
+    'rmse': rmse,
+    'grad': grad,
+    's1': s1,
+    "psnr": psnr,
+    "ncc": normalized_cross_correlation,
+    "gds": gradient_difference_similarity,
+    "gmd": gradient_magnitude_difference,
+    "hist_int": histogram_intersection,
+    "gpd": gradient_profile_difference,
+    "hog-pearson": hog_pearson
+}
+
+single_metrics = ["grad", "s1"]
+
+
+def compute_all_metrics(X, T) -> dict:
+    """Compute all evaluation metrics."""
+    results = dict()
+    metrics_to_compute = single_metrics if T is None else metric_f.keys()
+
+    for metric in metrics_to_compute:
+        f = metric_f.get(metric)
+        if f is not None:
+            try:
+                if T is not None:
+                    if metric in single_metrics:
+                        results[metric] = (f(X), f(T))
+                    else:
+                        results[metric] = f(X, T)
+                else:
+                    results[metric] = f(X)
+            except Exception as e:
+                print(f'Failed to compute {metric}: {e}')
+        else:
+            print(f'Unknown metric name: {metric}')
+
+    return results
+
+
+def compute_metric(X, T, metric: str):
+    """Compute specified evaluation metric"""
+    f = metric_f.get(metric)
+    if f is None:
+        raise ValueError(f'Unknown metric name: {metric}')
+
+    if T is not None:
+        if metric in single_metrics:
+            return f(X), f(T)
+        else:
+            return f(X, T)
+    else:
+        return f(X)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -19,7 +19,7 @@ metric_f = {
     "ncc": normalized_cross_correlation,
     "gds": gradient_difference_similarity,
     "gmd": gradient_magnitude_difference,
-    "hist_int": histogram_intersection,
+    "hist-int": histogram_intersection,
     "gpd": gradient_profile_difference,
     "hog-pearson": hog_pearson
 }
@@ -38,7 +38,7 @@ def compute_all_metrics(X, T) -> dict:
             try:
                 if T is not None:
                     if metric in single_metrics:
-                        results[metric] = (f(X), f(T))
+                        results[metric] = f(X), f(T)
                     else:
                         results[metric] = f(X, T)
                 else:

--- a/src/benchmark.py
+++ b/src/benchmark.py
@@ -1,9 +1,9 @@
 import argparse
 import matplotlib.pyplot as plt
 
-from dataloader import generate_synthetic_data, load_data, synthetic_f
-from transforms import apply_transform, transform_d
-from metrics import compute_metric, compute_all_metrics, metric_f
+from sharpness.dataloader import generate_synthetic_data, load_data, synthetic_f
+from sharpness.transforms import apply_transform, transform_d
+from sharpness import compute_metric, compute_all_metrics, metric_f
 
 
 parser = argparse.ArgumentParser(description='Sharpness Benchmarks')

--- a/src/fourier.py
+++ b/src/fourier.py
@@ -1,0 +1,31 @@
+import cv2
+import numpy as np
+
+def compute_power_spectrum(image):
+    # Compute the power spectrum of an image
+    f_transform = np.fft.fft2(image)
+    power_spectrum = np.abs(f_transform) ** 2
+    return power_spectrum
+
+def compute_image_similarity(image1, image2):
+    # Compute power spectra of both images
+    power_spectrum1 = compute_power_spectrum(image1)
+    power_spectrum2 = compute_power_spectrum(image2)
+
+    # Compute the normalized cross-correlation between power spectra
+    cross_correlation = np.real(np.fft.ifft2(np.fft.fft2(power_spectrum1) * np.conj(np.fft.fft2(power_spectrum2))))
+    cross_correlation /= np.max(cross_correlation)
+
+    # The maximum value of the cross-correlation indicates similarity
+    similarity_score = np.max(cross_correlation)
+
+    return similarity_score
+
+
+if __name__ == '__main__':
+    from skimage.data import camera
+    image1 = camera()
+    image2 = camera()
+
+    similarity_score = compute_image_similarity(image1, image2)
+    print("Similarity Score:", similarity_score)

--- a/src/fourier.py
+++ b/src/fourier.py
@@ -7,7 +7,7 @@ def compute_power_spectrum(image):
     power_spectrum = np.abs(f_transform) ** 2
     return power_spectrum
 
-def compute_image_similarity(image1, image2):
+def fourier_image_similarity(image1, image2):
     # Compute power spectra of both images
     power_spectrum1 = compute_power_spectrum(image1)
     power_spectrum2 = compute_power_spectrum(image2)
@@ -27,5 +27,5 @@ if __name__ == '__main__':
     image1 = camera()
     image2 = camera()
 
-    similarity_score = compute_image_similarity(image1, image2)
+    similarity_score = fourier_image_similarity(image1, image2)
     print("Similarity Score:", similarity_score)

--- a/src/fourier.py
+++ b/src/fourier.py
@@ -21,6 +21,11 @@ def fourier_image_similarity(image1, image2):
 
     return similarity_score
 
+def fourier_total_variation(image):
+    f_transform = np.fft.fft2(image)
+    tv = np.sum(np.abs(f_transform))
+    return tv
+
 
 if __name__ == '__main__':
     from skimage.data import camera

--- a/src/gradient.py
+++ b/src/gradient.py
@@ -2,65 +2,14 @@ import cv2
 import numpy as np
 from skimage.feature import hog
 from scipy.stats import pearsonr
-
-
-def compute_gradient_metrics(image1, image2, pool=None, normalize=False):
-    metrics_dictionary = {}
-    
-    if normalize:
-        image1 = normalize_image(image1)
-        image2 = normalize_image(image2)
-    
-    # Define a list of metric functions
-    metric_functions = [
-        ("psnr", psnr),
-        ("ncc", normalized_cross_correlation),
-        ("gds", gradient_difference_similarity),
-        ("gmd", gradient_magnitude_difference),
-        ("hist_int", histogram_intersection),
-        ("gpd", gradient_profile_difference),
-        ("hog-pearson", hog_pearson),
-    ]
-    
-    # Parallel processing function
-    def compute_metric(metric_name, metric_func):
-        metric_value = metric_func(image1, image2)
-        return metric_name, metric_value
-    
-    if pool is not None:
-        # Use parallel processing
-        metric_results = pool.starmap(compute_metric, metric_functions)
-    else:
-        # Use sequential processing
-        metric_results = [compute_metric(name, func) for name, func in metric_functions]
-    
-    # Store the metric results in the dictionary
-    for name, value in metric_results:
-        metrics_dictionary[name] = value
-        
-    # Single-image grad metrics
-    mgm1 = mean_gradient_magnitude(image1)
-    mgm2 = mean_gradient_magnitude(image2) 
-    metrics_dictionary["mgm"] = (mgm1, mgm2)
-    
-    return metrics_dictionary
-
-
-def normalize_image(image, new_min=0, new_max=1):
-    # Find the minimum and maximum pixel values in the image
-    min_val = np.min(image)
-    max_val = np.max(image)
-    
-    # Scale the image to the [new_min, new_max] range
-    normalized_image = (image - min_val) / (max_val - min_val) * (new_max - new_min) + new_min
-    
-    return normalized_image
+from sharpness.metrics import gray_and_flatten
 
 
 def psnr(image1, image2):
     mse = np.mean((image1 - image2) ** 2)
     max_pixel_value = np.max(image1)
-    psnr_value = 20 * np.log10(max_pixel_value / np.sqrt(mse))
+    eps = np.finfo(np.float32).tiny
+    psnr_value = 20 * np.log10(max_pixel_value / (eps + np.sqrt(mse)))
     return psnr_value
 
 
@@ -69,7 +18,10 @@ def normalized_cross_correlation(image1, image2):
     return ncc
 
 
-def histogram_intersection(image1, image2, bins=256):  # This assumes 1 color channel 
+def histogram_intersection(image1, image2, bins=256):
+    image1 = gray_and_flatten(image1)
+    image2 = gray_and_flatten(image2)
+
     hist1, _ = np.histogram(image1.flatten(), bins=bins, range=[0, 256])
     hist2, _ = np.histogram(image2.flatten(), bins=bins, range=[0, 256])
     intersection = np.minimum(hist1, hist2).sum() / np.maximum(hist1, hist2).sum()
@@ -77,73 +29,72 @@ def histogram_intersection(image1, image2, bins=256):  # This assumes 1 color ch
 
 
 def gradient_difference_similarity(image1, image2):
-    # Calculate gradients of the images
+    image1 = gray_and_flatten(image1)
+    image2 = gray_and_flatten(image2)
+
     gradient_x1 = cv2.Sobel(image1, cv2.CV_64F, 1, 0, ksize=3)
     gradient_y1 = cv2.Sobel(image1, cv2.CV_64F, 0, 1, ksize=3)
-    gradient_magnitude1 = np.sqrt(gradient_x1**2 + gradient_y1**2)
+    gradient_magnitude1 = np.sqrt(gradient_x1 ** 2 + gradient_y1 ** 2)
 
     gradient_x2 = cv2.Sobel(image2, cv2.CV_64F, 1, 0, ksize=3)
     gradient_y2 = cv2.Sobel(image2, cv2.CV_64F, 0, 1, ksize=3)
-    gradient_magnitude2 = np.sqrt(gradient_x2**2 + gradient_y2**2)
+    gradient_magnitude2 = np.sqrt(gradient_x2 ** 2 + gradient_y2 ** 2)
 
-    # Compute the Gradient Difference Similarity
     gds = np.sum(np.abs(gradient_magnitude1 - gradient_magnitude2)) / np.sum(gradient_magnitude1 + gradient_magnitude2)
-
     return gds
 
 
 def gradient_magnitude_difference(image1, image2):
-    # Calculate gradients of the images
+    image1 = gray_and_flatten(image1)
+    image2 = gray_and_flatten(image2)
+
     gradient_x1 = cv2.Sobel(image1, cv2.CV_64F, 1, 0, ksize=3)
     gradient_y1 = cv2.Sobel(image1, cv2.CV_64F, 0, 1, ksize=3)
-    gradient_magnitude1 = np.sqrt(gradient_x1**2 + gradient_y1**2)
+    gradient_magnitude1 = np.sqrt(gradient_x1 ** 2 + gradient_y1 ** 2)
 
     gradient_x2 = cv2.Sobel(image2, cv2.CV_64F, 1, 0, ksize=3)
     gradient_y2 = cv2.Sobel(image2, cv2.CV_64F, 0, 1, ksize=3)
-    gradient_magnitude2 = np.sqrt(gradient_x2**2 + gradient_y2**2)
+    gradient_magnitude2 = np.sqrt(gradient_x2 ** 2 + gradient_y2 ** 2)
 
-    # Compute the Gradient Magnitude Difference
     gmd = np.sum(np.abs(gradient_magnitude1 - gradient_magnitude2))
-
     return gmd
 
 
 def gradient_profile_difference(image1, image2):
-    # Calculate gradients of the images
+    image1 = gray_and_flatten(image1)
+    image2 = gray_and_flatten(image2)
+
     gradient_x1 = cv2.Sobel(image1, cv2.CV_64F, 1, 0, ksize=3)
     gradient_y1 = cv2.Sobel(image1, cv2.CV_64F, 0, 1, ksize=3)
-    gradient_magnitude1 = np.sqrt(gradient_x1**2 + gradient_y1**2)
+    gradient_magnitude1 = np.sqrt(gradient_x1 ** 2 + gradient_y1 ** 2)
 
     gradient_x2 = cv2.Sobel(image2, cv2.CV_64F, 1, 0, ksize=3)
     gradient_y2 = cv2.Sobel(image2, cv2.CV_64F, 0, 1, ksize=3)
-    gradient_magnitude2 = np.sqrt(gradient_x2**2 + gradient_y2**2)
+    gradient_magnitude2 = np.sqrt(gradient_x2 ** 2 + gradient_y2 ** 2)
 
-    # Compute the Gradient Profile Difference
     gpd = np.sum(np.abs(np.array(np.gradient(gradient_magnitude1)) - np.array(np.gradient(gradient_magnitude2))))
-
     return gpd
 
 
 def histogram_of_oriented_gradients(image):
-    # Compute Histogram of Oriented Gradients (HOG) features
-    hog_features, _ = hog(image, orientations=8, pixels_per_cell=(16, 16),
-                          cells_per_block=(1, 1), visualize=True)
-    
+    image = gray_and_flatten(image)
+    hog_features, _ = hog(image, orientations=8, pixels_per_cell=(16, 16), cells_per_block=(1, 1), visualize=True)
     return hog_features
 
 
 def hog_pearson(image1, image2):
     hog_features_1 = histogram_of_oriented_gradients(image1)
     hog_features_2 = histogram_of_oriented_gradients(image2)
-    
+
     #squared_diff = [(x - y) ** 2 for x, y in zip(hog_features_1, hog_features_2)]
     #distance = sum(squared_diff) ** 0.5
-    
+
     # HOG features for two images (hog_features_1 and hog_features_2)
     return pearsonr(hog_features_1, hog_features_2)[0]
 
 
 def mean_gradient_magnitude(image):
+    image = gray_and_flatten(image)
     # Calculate gradients of the image
     gradient_x = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=3)
     gradient_y = cv2.Sobel(image, cv2.CV_64F, 0, 1, ksize=3)
@@ -187,7 +138,8 @@ if __name__ == "__main__":
     print("GPD:", gpd_value)
 
     # Calculate Histogram of Oriented Gradients (HOG) for the image
-    hog_features = histogram_of_oriented_gradients(image1)
+    hog = hog_pearson(image1, image2)
+    print("HOG pearson", hog)
 
     # Calculate Mean Gradient Magnitude
     mgm_value = mean_gradient_magnitude(image1)

--- a/src/gradient.py
+++ b/src/gradient.py
@@ -105,6 +105,19 @@ def mean_gradient_magnitude(image):
 
     return mgm
 
+def grad_total_variation(image):
+    # Ensure the image is a NumPy array with float data type
+    image = image.astype(float)
+
+    # Calculate the horizontal and vertical gradients using central differences
+    gradient_x = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=3)
+    gradient_y = cv2.Sobel(image, cv2.CV_64F, 0, 1, ksize=3)
+
+    # Compute the total variation as the L1 norm of the gradients
+    tv = np.sum(np.abs(gradient_x)) + np.sum(np.abs(gradient_y))
+
+    return tv
+
 
 # Example usage:
 if __name__ == "__main__":

--- a/src/gradient.py
+++ b/src/gradient.py
@@ -1,5 +1,4 @@
 import cv2
-import torch
 import numpy as np
 from skimage.feature import hog
 from scipy.stats import pearsonr
@@ -21,7 +20,6 @@ def compute_gradient_metrics(image1, image2, pool=None, normalize=False):
         ("hist_int", histogram_intersection),
         ("gpd", gradient_profile_difference),
         ("hog-pearson", hog_pearson),
-        # Add more metrics here if needed
     ]
     
     # Parallel processing function
@@ -60,14 +58,6 @@ def normalize_image(image, new_min=0, new_max=1):
 
 
 def psnr(image1, image2):
-    if isinstance(image1, torch.Tensor) and isinstance(image2, torch.Tensor):
-        # Calculate PSNR using Torch tensors (GPU if available)
-        mse = torch.mean((image1 - image2) ** 2)
-        max_pixel_value = torch.max(image1)
-        psnr_value = 20 * torch.log10(max_pixel_value / torch.sqrt(mse))
-        return psnr_value.item()  # Convert to NumPy float
-
-    # Calculate PSNR using NumPy arrays (CPU)
     mse = np.mean((image1 - image2) ** 2)
     max_pixel_value = np.max(image1)
     psnr_value = 20 * np.log10(max_pixel_value / np.sqrt(mse))
@@ -75,10 +65,6 @@ def psnr(image1, image2):
 
 
 def normalized_cross_correlation(image1, image2):
-    if isinstance(image1, torch.Tensor) and isinstance(image2, torch.Tensor):
-        ncc = torch.sum(image1 * image2) / (torch.sqrt(torch.sum(image1 ** 2)) * torch.sqrt(torch.sum(image2 ** 2)))
-        return ncc
-        
     ncc = np.sum(image1 * image2) / (np.sqrt(np.sum(image1 ** 2)) * np.sqrt(np.sum(image2 ** 2)))
     return ncc
 
@@ -175,11 +161,10 @@ if __name__ == "__main__":
     from skimage.data import camera
     image1 = camera()
     image2 = camera()
-    #image = cv2.imread("image.jpg", cv2.IMREAD_GRAYSCALE)
 
-    # Calculate PSNR
+    #  Calculate psnr
     psnr_value = psnr(image1, image2)
-    print("PSNR:", psnr_value)
+    print("psnr:", psnr_value)
 
     # Calculate Normalized Cross-Correlation
     ncc_value = normalized_cross_correlation(image1, image2)

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,8 +1,6 @@
 import numpy as np
 from skimage import filters
-from spec_slope import s1_map
-from gradient import compute_gradient_metrics
-
+from sharpness.spec_slope import s1_map
 
 def mse(X, T):
     """Mean Squared Error"""
@@ -19,16 +17,16 @@ def rmse(X, T):
     return np.sqrt(mse(X, T))
 
 
-def grad(X, T):
+def grad(X):
     """Average Magnitude of the Gradient
 
     Edge magnitude is computed as:
         sqrt(Gx^2 + Gy^2)
     """
     def _f(x): return np.mean(filters.sobel(x))
-    return (_f(X), _f(T))
+    return _f(X)
 
-def s1(X, T):
+def s1(X):
     """Spectral slope method from Vu et al.
     
     Computes a sharpness map of the image, then returns the
@@ -38,44 +36,7 @@ def s1(X, T):
     input separately and returns a tuple.
     """
     X_map = s1_map(X, 32, 16)
-    T_map = s1_map(T, 32, 16)
-    return (
-        X_map[X_map > np.percentile(X_map, 99)].mean(),
-        T_map[T_map > np.percentile(T_map, 99)].mean()
-    )
-
-
-######### Default Metrics #########
-metric_f = {
-    'mse': mse,
-    'mae': mae,
-    'rmse': rmse,
-    'grad': grad,
-    's1': s1
-}
-
-
-def compute_all_metrics(X, T) -> dict:
-    """Compute all evaluation metrics."""
-    results = dict()
-    for metric, f in metric_f.items():
-        try:
-            results[metric] = f(X, T)
-        except Exception as e:
-            print(f'Failed to compute {metric}: {e}')
-            
-    """ Add imported gradient metrics """
-    results.update(compute_gradient_metrics(X, T))
-            
-    return results
-
-
-def compute_metric(X, T, metric: str):
-    """Compute specified evaluation metric"""
-    f = metric_f.get(metric)
-    if f is None:
-        raise ValueError(f'Unknown metric name: {metric}')
-    return f(X, T)
+    return X_map[X_map > np.percentile(X_map, 99)].mean()
 
 
 if __name__ == '__main__':
@@ -83,6 +44,7 @@ if __name__ == '__main__':
     X = camera()
     T = np.fliplr(X)
 
+    from sharpness import compute_all_metrics
     results = compute_all_metrics(X, T)
     for metric, result in results.items():
         print(f'{metric}: {result}')

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,6 +1,15 @@
 import numpy as np
 from skimage import filters
 from sharpness.spec_slope import s1_map
+from skimage.color import rgb2gray
+
+def gray_and_flatten(image):
+    if image.ndim == 3:
+        if  image.shape[-1] > 1:
+            image = rgb2gray(image)
+    image = np.squeeze(image).astype(np.float32)
+    return image
+
 
 def mse(X, T):
     """Mean Squared Error"""
@@ -35,6 +44,7 @@ def s1(X):
     Because this is not a comparative method, looks at each
     input separately and returns a tuple.
     """
+    X = gray_and_flatten(X)
     X_map = s1_map(X, 32, 16)
     return X_map[X_map > np.percentile(X_map, 99)].mean()
 

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -49,6 +49,14 @@ def s1(X):
     return X_map[X_map > np.percentile(X_map, 99)].mean()
 
 
+def total_variation(X):
+    """ Total variation of an image """
+    horizontal_tv = np.sum(np.abs(X[:, :-1] - X[:, 1:]))
+    vertical_tv = np.sum(np.abs(X[:-1, :] - X[1:, :]))
+    tv = horizontal_tv + vertical_tv
+    return tv
+
+
 if __name__ == '__main__':
     from skimage.data import camera
     X = camera()

--- a/src/wavelet.py
+++ b/src/wavelet.py
@@ -32,6 +32,20 @@ def wavelet_image_similarity(image1, image2):
 
     return similarity_score
 
+def wavelet_total_variation(image, wavelet='haar', level=1):
+    # Ensure the image is a NumPy array with float data type
+    image = image.astype(float)
+
+    # Apply wavelet transform
+    coeffs = pywt.wavedec2(image, wavelet, level=level)
+
+    # Calculate the Wavelet Total Variation
+    wavelet_tv = 0
+    for c in coeffs:
+        wavelet_tv += np.sum(np.abs(c))
+
+    return wavelet_tv
+
 # Example usage:
 if __name__ == '__main__':
     from skimage.data import camera
@@ -40,3 +54,6 @@ if __name__ == '__main__':
 
     similarity_score = wavelet_image_similarity(image1, image2)
     print("Similarity Score:", similarity_score)
+    wavelet_tv1 = wavelet_total_variation(image1)
+    wavelet_tv2 = wavelet_total_variation(image2)
+    print("Total variation of the two images:", wavelet_tv1, wavelet_tv2)

--- a/src/wavelet.py
+++ b/src/wavelet.py
@@ -1,0 +1,42 @@
+import cv2
+import numpy as np
+import pywt
+
+def compute_wavelet_energy(image, wavelet='haar', level=1):
+    coeffs = pywt.wavedec2(image, wavelet, level=level)
+    energy = 0
+    for c in coeffs:
+        energy += np.sum(np.abs(c) ** 2)
+    return energy
+
+def compute_wavelet_entropy(image, wavelet='haar', level=1):
+    coeffs = pywt.wavedec2(image, wavelet, level=level)
+    entropy = 0
+    for c in coeffs:
+        normalized_c = np.abs(c) / np.sum(np.abs(c))
+        entropy += -np.sum(normalized_c * np.log2(normalized_c + np.finfo(float).eps))
+    return entropy
+
+def compute_image_similarity(image1, image2):
+    energy1 = compute_wavelet_energy(image1)
+    energy2 = compute_wavelet_energy(image2)
+    entropy1 = compute_wavelet_entropy(image1)
+    entropy2 = compute_wavelet_entropy(image2)
+
+    # Calculate similarity scores based on energy and entropy
+    energy_similarity = np.exp(-abs(energy1 - energy2))
+    entropy_similarity = np.exp(-abs(entropy1 - entropy2))
+
+    # A weighted combination of energy and entropy similarity can be used
+    similarity_score = 0.5 * energy_similarity + 0.5 * entropy_similarity
+
+    return similarity_score
+
+# Example usage:
+if __name__ == '__main__':
+    from skimage.data import camera
+    image1 = camera()
+    image2 = camera()
+
+    similarity_score = compute_image_similarity(image1, image2)
+    print("Similarity Score:", similarity_score)

--- a/src/wavelet.py
+++ b/src/wavelet.py
@@ -17,7 +17,7 @@ def compute_wavelet_entropy(image, wavelet='haar', level=1):
         entropy += -np.sum(normalized_c * np.log2(normalized_c + np.finfo(float).eps))
     return entropy
 
-def compute_image_similarity(image1, image2):
+def wavelet_image_similarity(image1, image2):
     energy1 = compute_wavelet_energy(image1)
     energy2 = compute_wavelet_energy(image2)
     entropy1 = compute_wavelet_entropy(image1)
@@ -38,5 +38,5 @@ if __name__ == '__main__':
     image1 = camera()
     image2 = camera()
 
-    similarity_score = compute_image_similarity(image1, image2)
+    similarity_score = wavelet_image_similarity(image1, image2)
     print("Similarity Score:", similarity_score)


### PR DESCRIPTION
The main changes are 

(1) the compute metrics calls and the list of metrics was moved to src/__init__.py, so that one can access the metrics via

from sharpness import compute_all_metrics 

(2) That method will automatically check if you entered X  or X and T. If X only, only single-image metrics are returned. Else all metrics are returned and single metrics are computed for each X and T and returned as a tuple. 

I did a little light modifications inside metrics.py (just removing T from the two single-image metrics "grad" and "s1" and calling each one at a time in __init__ when there are two images. 