### PR TITLE
Fix incorrect RMSE calculation

### DIFF
--- a/src/sharpness/metrics.py
+++ b/src/sharpness/metrics.py
@@ -21,7 +21,7 @@ from functools import partial
 
 def rmse(X, T):
     """Bivariate -- Root Mean Squared Error"""
-    return np.sqrt(np.mean(X - T) ** 2)
+    return np.sqrt(np.mean((X - T) ** 2))
 
 
 def ssim(X, T, win_size=7, data_range=255):


### PR DESCRIPTION
This PR fixes a bug in the RMSE metric implementation.

Previously, the RMSE function was computing the square of the mean difference between two arrays X and T, rather than the mean of the squared differences. This resulted in incorrect values being returned.

Buggy implementation:

``` python
def rmse(X, T):
    return np.sqrt(np.mean(X - T) ** 2)
```

Corrected implementation:

``` python
def rmse(X, T):
    return np.sqrt(np.mean((X - T) ** 2))
```

This change ensures that the RMSE is calculated according to its standard definition.
